### PR TITLE
Loss of precision when deducting fees on deposits

### DIFF
--- a/lib/deposits/index.js
+++ b/lib/deposits/index.js
@@ -4,7 +4,8 @@
 var deposit = {},
 config = require('../../config'),
 wallet = require('../resources/wallet'),
-bitcoin = require('bitcoin');
+bitcoin = require('bitcoin'),
+BigNumber = require('bignumber.js');
 
 
 wallet.persist(config.datasource);
@@ -40,32 +41,34 @@ deposit.start = function (options) {
 
       var key = keys.pop();
       var account = key,
-          amount = accounts[key];
+          amount = new BigNumber(accounts[key] === '' ? 0 : accounts[key]);
 
       // Don't attempt to send amounts of 0, or from the default "" account
-      if (amount === 0 || account === "") {
+      if (amount.equals(0)) {
         return processTransactions(keys);
       }
 
       // Apply transaction fee to deposit
       switch (options.currency) {
         case 'dogecoin':
-          amount = amount - 0.01;
+          amount = amount.minus(0.01);
         break;
         case 'peercoin':
-          amount = amount - 0.01;
+          amount = amount.minus(0.01);
         break;
         case 'bitcoin':
-          amount = amount - 0.0001;
+          amount = amount.minus(0.0001);
         break;
         default:
         break;
       }
 
       // Not enough of a balance to send ( transaction fee + amount exceeded total balance )
-      if (amount <= 0) {
+      if (amount.lte(0)) {
         return processTransactions(keys);
       }
+
+      amount = Number(amount);
 
       console.log('OUTGOING -> ', coldAddress, amount, account);
       client.cmd('sendfrom', account, coldAddress, amount, function (err, result) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "resource-http": "https://github.com/bigcompany/resource-http/tarball/master",
     "resource-user": "https://github.com/bigcompany/resource-user/tarball/master",
     "resource-wallet": "https://github.com/bigcompany/resource-wallet/tarball/master",
-    "view": "0.5.x"
+    "view": "0.5.x",
+    "bignumber.js": "~1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The world's first open-source crypto-currency bank.",
   "main": "index.js",
   "scripts": {
-    "test": "tap /test"
+    "test": "tap test"
   },
   "bin": {
     "safe-deposits": "./bin/deposits",


### PR DESCRIPTION
A case of such precision loss occurs due to binary floating point rounding. In our case an example case is when a user's bitcoin balance has 0.059 or 0.05900001 BTC or similar, then the deduction of 0.0001 BTC fee happens which results to totals of 0.058899999999999994 and 0.058900009999999996 accordingly.

In order to solve this and be able to do precise calculations with a lot of decimals, I added a new NPM package: [bignumber.js](/MikeMcl/bignumber.js), let me know if you prefer something else.

About the test, I haven't managed to get couchdb running and couldn't figure out a quick way to have a unit test for this case with the structure of [lib/deposits/index.js](/bigcompany/safewallet/blob/master/lib/deposits/index.js), although I did a dirty refactoring locally to test it.
If you have any idea on making the test, let me know and I will prep the test.

-Sev
